### PR TITLE
prevent empty last snapshot files from causing a crash

### DIFF
--- a/packaging/rpm/cvmfs-servermon.spec
+++ b/packaging/rpm/cvmfs-servermon.spec
@@ -1,6 +1,6 @@
 Summary: CernVM File System Server Monitoring
 Name: cvmfs-servermon
-Version: 1.1
+Version: 1.2
 Release: 1%{?dist}
 BuildArch: noarch
 Group: Applications/System
@@ -45,6 +45,10 @@ install -p -m 444 webapi/* $RPM_BUILD_ROOT/usr/share/cvmfs-servermon/webapi
 /usr/share/cvmfs-servermon
 
 %changelog
+* Thu Mar 03 2016 Dave Dykstra <dwd@fnal.gov> - 1.2-1
+- Prevent empty .cvmfs_last_snapshot files (which can happen when a disk
+  fills up) from causing a crash and stack trace.
+
 * Fri Feb 05 2016 Dave Dykstra <dwd@fnal.gov> - 1.1-1
 - Change test format name from 'ok' to 'status' as was planned and
   documented in the comments.

--- a/webapi/cvmfsmon_updated.py
+++ b/webapi/cvmfsmon_updated.py
@@ -9,6 +9,8 @@ def runtest(repo, serverurl):
     try:
         request = urllib2.Request(url, headers={"Cache-control" : "max-age=30"})
         snapshot_string = urllib2.urlopen(request).read()
+        if snapshot_string == '':
+          return [ testname, repo, 'CRITICAL', url + ' error: empty snapshot date' ]
         snapshot_date = dateutil.parser.parse(snapshot_string)
     except urllib2.HTTPError, e:
         if e.code == 404:


### PR DESCRIPTION
See the [JIRA ticket](https://sft.its.cern.ch/jira/browse/CVM-994)